### PR TITLE
add rgpd consent as mandatory at registration

### DIFF
--- a/src/main/java/com/sdv/lootopia/domain/model/Utilisateur.java
+++ b/src/main/java/com/sdv/lootopia/domain/model/Utilisateur.java
@@ -25,6 +25,7 @@ public class Utilisateur {
     private String activationToken;
     private LocalDateTime activationTokenExpiration;
     private boolean compteActif = false;
+    private boolean rgpdConsent;
 
     @OneToMany(mappedBy = "utilisateur")
     private List<Participation> participations;

--- a/src/main/java/com/sdv/lootopia/web/controller/AuthController.java
+++ b/src/main/java/com/sdv/lootopia/web/controller/AuthController.java
@@ -31,8 +31,13 @@ public class AuthController {
 
     @PostMapping("/register")
     public ResponseEntity<?> register(@RequestBody RegistrationRequest registrationRequest) {
+        if (!Boolean.TRUE.equals(registrationRequest.getRgpdConsent())) {
+            return ResponseEntity.badRequest().body("Le consentement RGPD est obligatoire.");
+        }
+
         Utilisateur user = new Utilisateur();
         user.setMotDePasse(new org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder().encode(registrationRequest.getMotDePasse()));
+        user.setRgpdConsent(true);
         user.setEmail(registrationRequest.getEmail());
         user.setPseudo(registrationRequest.getPseudo());
 

--- a/src/main/java/com/sdv/lootopia/web/dto/RegistrationRequest.java
+++ b/src/main/java/com/sdv/lootopia/web/dto/RegistrationRequest.java
@@ -4,6 +4,7 @@ public class RegistrationRequest {
     private String email;
     private String pseudo;
     private String motDePasse;
+    private Boolean rgpdConsent;
 
     public String getEmail() { return email; }
     public void setEmail(String email) { this.email = email; }
@@ -14,5 +15,11 @@ public class RegistrationRequest {
     }
     public void setPseudo(String pseudo) {
         this.pseudo = pseudo;
+    }
+    public Boolean getRgpdConsent() {
+        return rgpdConsent;
+    }
+    public void setRgpdConsent(Boolean rgpdConsent) {
+        this.rgpdConsent = rgpdConsent;
     }
 }


### PR DESCRIPTION
Consent RGPD intégré dans la fonctionnalité d’enregistrement.
Cela signifie que :

- Le champ rgpdConsent est requis à l'inscription

- L'API refuse l'inscription si le consentement n’est pas donné

- Le consentement est stocké dans la base pour preuve